### PR TITLE
Remove  Component._count statements in diff.js

### DIFF
--- a/dist/power.dev.js
+++ b/dist/power.dev.js
@@ -538,9 +538,6 @@
         }
 
         var newElement = createElement(child, Component);
-        Component._count += 1;
-        newElement.setAttribute(DATA_NODE_ATTRIBUTE, Component._count);
-        child.props[DATA_NODE_ATTRIBUTE] = Component._count;
         element.appendChild(newElement);
         continue;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "power-js",
+  "name": "@power-js/core",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -4060,12 +4060,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4080,17 +4082,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4207,7 +4212,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4219,6 +4225,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4233,6 +4240,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4240,12 +4248,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4264,6 +4274,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4344,7 +4355,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4356,6 +4368,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4477,6 +4490,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/vdom/diff.js
+++ b/src/vdom/diff.js
@@ -96,12 +96,6 @@ export const childrenDiff = (oldChildren, newChildren, element, Component) => {
 
       const newElement = createElement(child, Component);
 
-      Component._count += 1;
-
-      newElement.setAttribute(DATA_NODE_ATTRIBUTE, Component._count);
-
-      child.props[DATA_NODE_ATTRIBUTE] = Component._count;
-
       element.appendChild(newElement);
 
       continue;


### PR DESCRIPTION
This PR removes the old `_counter` statements that was linked to every Component.